### PR TITLE
Rename accumulators

### DIFF
--- a/Advanced-Electric-Revamped-v16/changelog.txt
+++ b/Advanced-Electric-Revamped-v16/changelog.txt
@@ -1,4 +1,7 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.3.6
+  - Renamed "electric-energy-accumulators-1" to "electric-energy-accumulators" 
+---------------------------------------------------------------------------------------------------
 Version: 0.3.4
   - Added pt-BR language
   - fixed es-ES language

--- a/Advanced-Electric-Revamped-v16/info.json
+++ b/Advanced-Electric-Revamped-v16/info.json
@@ -1,6 +1,6 @@
 {
  "name": "Advanced-Electric-Revamped-v16",
- "version": "0.3.5",
+ "version": "0.3.6",
  "title": "Advanced Electric High Resolution",
  "contact": "https://twitter.com/xlshallox",
  "author": "LsHallo",

--- a/Advanced-Electric-Revamped-v16/prototypes/technology/advanced-accumulator.lua
+++ b/Advanced-Electric-Revamped-v16/prototypes/technology/advanced-accumulator.lua
@@ -12,7 +12,7 @@ data:extend(
         recipe = "advanced-accumulator"
       }
     },
-    prerequisites = {"electric-energy-accumulators-1"},
+    prerequisites = {"electric-energy-accumulators"},
     unit =
     {
       count = 150,


### PR DESCRIPTION
This PR updates the accumulator dependency in `advanced-accumulator` based on the name change announced [here](https://forums.factorio.com/viewtopic.php?f=3&t=68710).

In addition, since the current available version seems to be 0.3.5, I have bumped the version in `info.json` to 0.3.6 and made an appropriate entry in the changelog.