### PR TITLE
Space exploration compatibility

### DIFF
--- a/Advanced-Electric-Revamped-v16/data-final-fixes.lua
+++ b/Advanced-Electric-Revamped-v16/data-final-fixes.lua
@@ -45,3 +45,12 @@ if mods["FactorioExtended-Plus-Power"] == nil then
 	data.raw["accumulator"]["accumulator"].next_upgrade = "advanced-accumulator"
 	data.raw["solar-panel"]["solar-panel"].next_upgrade = "advanced-solar"
 end
+
+if mods["space-exploration"] then
+	local orig_accu = data.raw["accumulator"]["accumulator"]
+
+	-- space exploration changes the collision box from 0.9 to 0.8 in data.lua
+	data.raw["accumulator"]["advanced-accumulator"].collision_box = orig_accu.collision_box
+	data.raw["accumulator"]["elite-accumulator"].collision_box = orig_accu.collision_box
+	data.raw["accumulator"]["ultimate-accumulator"].collision_box = orig_accu.collision_box
+end


### PR DESCRIPTION
Space exploration for 2.0 is in closed testing, this compatibility issue came up, the pull request fixes that:
![image](https://github.com/user-attachments/assets/35dc7a8f-e5c7-4bea-a1bd-8fc2946ba4b0)
